### PR TITLE
fix event params with the same name aren't parsed correctly. Add QUALITIES_AVAILABLE event.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url 'http://repo1.maven.org/maven2' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-rc02'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -15,10 +15,8 @@ buildscript {
 
     allprojects {
         repositories {
+            google()
             jcenter()
-            maven {
-                url "https://maven.google.com"
-            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url 'http://repo1.maven.org/maven2' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.2.0-rc02'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/sdk/src/main/java/com/dailymotion/android/player/sdk/PlayerWebView.java
+++ b/sdk/src/main/java/com/dailymotion/android/player/sdk/PlayerWebView.java
@@ -69,6 +69,7 @@ public class PlayerWebView extends WebView {
     public static final String EVENT_CONTROLSCHANGE = "controlschange";
     public static final String EVENT_VOLUMECHANGE = "volumechange";
     public static final String EVENT_QUALITY = "qualitychange";
+    public static final String EVENT_QUALITIES_AVAILABLE = "qualitiesavailable";
     public static final String EVENT_PLAYBACK_READY = "playback_ready";
 
     private static final java.lang.String ASSETS_SCHEME = "asset://";
@@ -263,7 +264,15 @@ public class PlayerWebView extends WebView {
             if (s2.length == 1) {
                 map.put(s2[0], null);
             } else if (s2.length == 2) {
-                map.put(s2[0], s2[1]);
+                String paramKey = s2[0];
+                String paramValue = s2[1];
+
+                if (!map.containsKey(paramKey)) {
+                    map.put(paramKey, paramValue);
+                } else {
+                    String value = map.get(paramKey) + ";" + paramValue;
+                    map.put(paramKey, value);
+                }
             } else {
                 Timber.e("bad param: " + s);
             }


### PR DESCRIPTION
For instance qualitiesavailable event has several parameters with the name "qualities[]",
but the sdk shows only one now (qualities[]=144).

This fix allows to get all parameters separated by ";". (qualities[]="720;480;380;240;144 )

