### PR TITLE
Add 'sdk_version' parameter to the initialization url

### DIFF
--- a/sdk/src/main/java/com/dailymotion/android/player/sdk/PlayerWebView.kt
+++ b/sdk/src/main/java/com/dailymotion/android/player/sdk/PlayerWebView.kt
@@ -261,6 +261,7 @@ class PlayerWebView : WebView {
         val parameters: MutableMap<String?, String?> = HashMap()
         // the following parameters below are compulsory, make sure they are always defined
         parameters["app"] = context.packageName
+        parameters["sdk_version"] = BuildConfig.SDK_VERSION
         parameters["api"] = "nativeBridge"
         when {
             Utils.hasFireTV(context) -> parameters["client_type"] = "firetv"


### PR DESCRIPTION
The goal is to have the same parameters on both Android and iOS platforms.
"app" => the package app name
"sdk_version" => the Native SDK version

Then we could improve the support for our partners 👍 

