### PR TITLE
Provide tracking opt out state throw the native bridge

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,7 +3,7 @@ object Version {
     val minSdkVersion = 21
     val compileSdkVersion = 31
 
-    val androidPlugin = "7.1.0"
+    val androidPlugin = "7.1.1"
     val kotlin = "1.6.10"
 }
 

--- a/sdk/src/main/java/com/dailymotion/android/player/sdk/PlayerWebView.kt
+++ b/sdk/src/main/java/com/dailymotion/android/player/sdk/PlayerWebView.kt
@@ -773,7 +773,7 @@ class PlayerWebView @JvmOverloads constructor(
                     "omversion" to OMHelper.PARTNER_VERSION,
                     "tracking" to mapOf(
                         "reader.advertising.id" to adInfo?.id.orEmpty(),
-                        "reader.device.tracking" to (adInfo?.isLimitAdTrackingEnabled?.not() ?: false)
+                        "reader.lmt" to (adInfo?.isLimitAdTrackingEnabled ?: true)
                     )
                 )
             )


### PR DESCRIPTION
To ensure the tracking opt-out state is taken into account on Player side, then on ad servers,
we provide `reader.advertising.id` and `reader.lmt` via the Native bridge.

Previously we were using url parameters at player initialization, this is not totally safe as it's exposed.
To guarantee a smooth transition, we will keep it for the next release, then remove it in a future one.